### PR TITLE
Enable Unicode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,9 @@ RUN printf "gem: --no-rdoc --no-ri" >> /etc/gemrc && \
 # Pin the version if we need to
 ENV puppetversion "~> 4.2.1"
 
+# Enable Unicode
+ENV LANG C.UTF-8
+
 # Now do the bundle install. I Split this off to minimize differences between 3 and 4
 RUN PUPPET_GEM_VERSION=${puppetversion} bundler install --clean --system --gemfile /Gemfile
 


### PR DESCRIPTION
A recent update to the json Ruby library started raising this error:

```
$ bundle exec rake test
rake aborted!
Encoding::InvalidByteSequenceError: "\xC3" on US-ASCII
/usr/local/bundle/gems/json_pure-2.0.1/lib/json/common.rb:156:in `encode'
/usr/local/bundle/gems/json_pure-2.0.1/lib/json/common.rb:156:in `initialize'
/usr/local/bundle/gems/json_pure-2.0.1/lib/json/common.rb:156:in `new'
/usr/local/bundle/gems/json_pure-2.0.1/lib/json/common.rb:156:in `parse'
/usr/local/bundle/gems/json_pure-2.0.1/lib/json/common.rb:335:in `load'
/usr/local/bundle/gems/spdx-licenses-1.1.0/lib/spdx-licenses.rb:8:in `data'
/usr/local/bundle/gems/spdx-licenses-1.1.0/lib/spdx-licenses.rb:28:in `exist?'
```

which I tracked down to the the 'é' in 'Québec' from:
https://github.com/domcleal/spdx-licenses/blob/master/licenses.json

Update the image to enable Unicode.  The C.UTF-8 locale is sufficient
and already built in to the underlying ruby:2.1 image.  en_US.UTF-8
would be ideal, but it is not included in the image and it's not
really worth it to generate.
