### PR TITLE
Unset PUPPET_GEM_VERSION

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,17 +9,11 @@ RUN printf "gem: --no-rdoc --no-ri" >> /etc/gemrc && \
     gem install json -v '1.8.3' && \
     gem install bundler
 
-# Set Puppet Version
-# TODO: Eventually we wont need separate files for this
-# https://github.com/docker/docker/issues/14634
-# Pin the version if we need to
-ENV puppetversion "~> 4.2.1"
-
 # Enable Unicode
 ENV LANG C.UTF-8
 
 # Now do the bundle install. I Split this off to minimize differences between 3 and 4
-RUN PUPPET_GEM_VERSION=${puppetversion} bundler install --clean --system --gemfile /Gemfile
+RUN bundler install --clean --system --gemfile /Gemfile
 
 #Don't like that is sets clean in global config
 RUN bundle config --delete clean

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
 group :test do
   gem "rake"
-  gem "puppet", ENV['PUPPET_GEM_VERSION'] || '~> 4.2.1'
+  gem "puppet", ENV['PUPPET_GEM_VERSION'] || '~> 4.10.8'
   gem "rspec"
   gem "rspec-puppet"
   gem "puppetlabs_spec_helper"


### PR DESCRIPTION
setting ENV['PUPPET_GEM_VERSION'] in Dockerfile causes all gitlab CI runs to be stuck using that version unless overridden with a gitlab repo variable. Let the repo Gemfile dictate which version of the Puppet Gem to use. 

/cc @iamjamestl 