### PR TITLE
Set BUNDLE_JOBS = '1' (Default)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.1
+FROM ruby:2.1.9
 
 # Add Gemfile
 ADD Gemfile /
@@ -17,10 +17,6 @@ RUN bundler install --clean --system --gemfile /Gemfile
 
 #Don't like that is sets clean in global config
 RUN bundle config --delete clean
-#Let's not talk to the network to run faster
-RUN echo "BUNDLE_LOCAL: 'true'" >> /usr/local/bundle/config
-#Let's run even faster by doing jobs in parallel
-RUN echo "BUNDLE_JOBS: '4'" >> /usr/local/bundle/config
 
 # Our default command
 CMD rm -rf Gemfile.lock && \


### PR DESCRIPTION
Revert to using a single thread.
Issues discovered in dependency ordering in
multi-threaded asyncronous fetching and installing
of gems.

Closes #1