### PR TITLE
Build from ruby:2.4 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.1.9
+FROM ruby:2.4
 
 # Add Gemfile
 ADD Gemfile /
@@ -6,7 +6,6 @@ ADD Gemfile /
 # Configure to ever install a ruby gem docs then
 # Install the relevant gems and cleanup after
 RUN printf "gem: --no-rdoc --no-ri" >> /etc/gemrc && \
-    gem install json -v '1.8.3' && \
     gem install bundler
 
 # Enable Unicode

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ group :test do
   gem "puppetlabs_spec_helper"
   gem "metadata-json-lint"
   gem "rspec-puppet-facts"
-  gem 'rubocop'
   gem 'simplecov', '>= 0.11.0'
   gem 'simplecov-console'
   gem 'semantic_puppet'
@@ -22,6 +21,14 @@ group :test do
   gem 'puppet-lint-resource_reference_syntax'
 
   gem 'json_pure', '<= 2.0.1' if RUBY_VERSION < '2.0.0'
+
+  if RUBY_VERSION < '2.2.0'
+    gem "rubocop", "< 0.60.0"
+  else
+    # rubocop:disable Bundler/DuplicatedGem
+    gem "rubocop"
+    # rubocop:enable Bundler/DuplicatedGem
+  end
 end
 
 group :development do


### PR DESCRIPTION
Puppet Platform 5.5 includes Ruby 2.4.x.  We will be moving to that
version very soon.  Because of that, and because gems are very rapidly
starting to drop support for Ruby 2.1, start targeting Ruby 2.4 today.